### PR TITLE
(WIP) Use UniversalScheduler instead of BukkitScheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <relocations>
                 <relocation>
-                  <pattern>com.tcoded.folialib</pattern>
-                  <shadedPattern>cn.dsnbo.bedrockplayersupport.lib.folialib</shadedPattern>
+                  <pattern>com.github.Anon8281</pattern>
+                  <shadedPattern>cn.dsnbo.bedrockplayersupport.lib.universalScheduler</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>space.arim.dazzleconf</pattern>
@@ -126,18 +126,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>dev.folia</groupId>
-      <artifactId>folia-api</artifactId>
-      <version>1.19.4-R0.1-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tcoded</groupId>
-      <artifactId>FoliaLib</artifactId>
-      <version>0.3.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.geysermc.floodgate</groupId>
       <artifactId>api</artifactId>
       <version>2.2.2-SNAPSHOT</version>
@@ -186,6 +174,11 @@
       <artifactId>CatSeedLogin</artifactId>
       <version>1.4.1</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.Anon8281</groupId>
+      <artifactId>UniversalScheduler</artifactId>
+      <version>0.1.6</version>
     </dependency>
     <dependency>
       <groupId>su.nexmedia.auth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,18 +119,23 @@
   </repositories>
 
   <dependencies>
+    <!-- Spigot API -->
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
       <version>1.13-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Floodgate API -->
     <dependency>
       <groupId>org.geysermc.floodgate</groupId>
       <artifactId>api</artifactId>
       <version>2.2.2-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- CMI API -->
     <dependency>
       <groupId>com.zrips</groupId>
       <artifactId>cmi-api</artifactId>
@@ -138,6 +143,8 @@
       <scope>system</scope>
       <systemPath>${basedir}/lib/CMI-API9.6.5.0.jar</systemPath>
     </dependency>
+
+    <!-- CMI Lib -->
     <dependency>
       <groupId>com.zrips</groupId>
       <artifactId>cmi-lib</artifactId>
@@ -145,41 +152,55 @@
       <scope>system</scope>
       <systemPath>${basedir}/lib/CMILib1.4.4.0.jar</systemPath>
     </dependency>
+
+    <!-- EssentialsX -->
     <dependency>
       <groupId>net.essentialsx</groupId>
       <artifactId>EssentialsX</artifactId>
       <version>2.20.1</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- HuskHomes -->
     <dependency>
       <groupId>net.william278</groupId>
       <artifactId>huskhomes</artifactId>
       <version>4.5.5</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Lombok -->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- AuthMe -->
     <dependency>
       <groupId>fr.xephi</groupId>
       <artifactId>authme</artifactId>
       <version>5.6.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- CatSeedLogin -->
     <dependency>
       <groupId>com.github.CatSeed</groupId>
       <artifactId>CatSeedLogin</artifactId>
       <version>1.4.1</version>
       <scope>provided</scope>
     </dependency>
+
+    <!-- Universal Scheduler -->
     <dependency>
       <groupId>com.github.Anon8281</groupId>
       <artifactId>UniversalScheduler</artifactId>
       <version>0.1.6</version>
     </dependency>
+
+    <!-- NexAuth -->
     <dependency>
       <groupId>su.nexmedia.auth</groupId>
       <artifactId>NexAuth</artifactId>
@@ -187,6 +208,8 @@
       <scope>system</scope>
       <systemPath>${basedir}/lib/NexAuth-2.0.3.jar</systemPath>
     </dependency>
+
+    <!-- NexEngine -->
     <dependency>
       <groupId>su.nexmedia.engine</groupId>
       <artifactId>NexEngine</artifactId>
@@ -194,6 +217,8 @@
       <scope>system</scope>
       <systemPath>${basedir}/lib/NexEngine.jar</systemPath>
     </dependency>
+
+    <!-- Ext Snakeyaml -->
     <dependency>
       <groupId>space.arim.dazzleconf</groupId>
       <artifactId>dazzleconf-ext-snakeyaml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,14 +84,17 @@
       <id>opencollab-snapshot</id>
       <url>https://repo.opencollab.dev/main/</url>
     </repository>
+    <!-- Maven Central -->
     <repository>
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/groups/public/</url>
     </repository>
+    <!-- EssentialsX -->
     <repository>
       <id>essentials-releases</id>
       <url>https://repo.essentialsx.net/releases/</url>
     </repository>
+    <!-- PaperMC -->
     <repository>
       <id>paper-repo</id>
       <url>https://papermc.io/repo/repository/maven-public/</url>

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/BedrockPlayerSupport.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/BedrockPlayerSupport.java
@@ -81,15 +81,16 @@ public final class BedrockPlayerSupport extends JavaPlugin {
     mainConfigManager = ConfigManager.create(getDataFolder().toPath(), "config.yml", Config.class);
     getMainConfigManager().reloadConfig();
     Config config = getMainConfigManager().getConfigData();
-    if (config.checkUpdate()) {
-      Update.checkUpdate(version -> {
-        if (getDescription().getVersion().equals(version)) {
-          getLogger().info("当前版本已经是最新");
-        } else {
-          getLogger().info("检测到新版本, 请更新插件");
-        }
-      });
-    }
+    // Temporary disable version checker to prepare for bug fix release
+//    if (config.checkUpdate()) {
+//      Update.checkUpdate(version -> {
+//        if (getDescription().getVersion().equals(version)) {
+//          getLogger().info("当前版本已经是最新");
+//        } else {
+//          getLogger().info("检测到新版本, 请更新插件");
+//        }
+//      });
+//    }
     if (config.enableTeleportForm()) {
       getCommand("tpgui").setExecutor(new TpFormCommand());
     }

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/BedrockPlayerSupport.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/BedrockPlayerSupport.java
@@ -15,6 +15,8 @@ import cn.dsnbo.bedrockplayersupport.listener.login.AuthMeListener;
 import cn.dsnbo.bedrockplayersupport.listener.teleport.CMITeleportListener;
 import cn.dsnbo.bedrockplayersupport.listener.teleport.EssXTeleportListener;
 import cn.dsnbo.bedrockplayersupport.util.Update;
+import com.github.Anon8281.universalScheduler.UniversalScheduler;
+import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -33,6 +35,8 @@ public final class BedrockPlayerSupport extends JavaPlugin {
   private static BasicPlugin basicPlugin;
   @Getter
   private static ConfigManager<Config> mainConfigManager;
+  @Getter
+  private static TaskScheduler scheduler;
   private boolean isCmiEnabled;
   private boolean isEssxEnabled;
   private boolean isHuskHomesEnabled;
@@ -42,9 +46,11 @@ public final class BedrockPlayerSupport extends JavaPlugin {
   private boolean isFloodgateEnabled;
 
 
+
   @Override
   public void onEnable() {
     instance = this;
+    scheduler = UniversalScheduler.getScheduler(this);
     floodgateApi = FloodgateApi.getInstance();
     new MainForm();
     loadConfig();
@@ -156,6 +162,7 @@ public final class BedrockPlayerSupport extends JavaPlugin {
       }
     }
   }
+
 
   private void registerAuthListener() {
     if (getMainConfigManager().getConfigData().enableLogin()

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/Metrics.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/Metrics.java
@@ -101,7 +101,7 @@ public class Metrics {
                         enabled,
                         this::appendPlatformData,
                         this::appendServiceData,
-                        submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                        submitDataTask -> BedrockPlayerSupport.getScheduler().runTask(submitDataTask),
                         plugin::isEnabled,
                         (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
                         (message) -> this.plugin.getLogger().log(Level.INFO, message),

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/form/MainForm.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/form/MainForm.java
@@ -117,8 +117,8 @@ public class MainForm {
                 .button1("§a是")
                 .button2("§c否")
                 .validResultHandler(((modalForm, modalFormResponse) -> {
-                    switch (modalFormResponse.clickedButtonId()) {
-                        case 0 -> player.chat("/back");
+                    if (modalFormResponse.clickedButtonId() == 0) {
+                        player.chat("/back");
                     }
                 }));
         BedrockPlayerSupport.getFloodgateApi().sendForm(player.getUniqueId(), form);

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/PlayerListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/PlayerListener.java
@@ -3,7 +3,6 @@ package cn.dsnbo.bedrockplayersupport.listener;
 import cn.dsnbo.bedrockplayersupport.BedrockPlayerSupport;
 import cn.dsnbo.bedrockplayersupport.config.Config;
 import cn.dsnbo.bedrockplayersupport.form.MainForm;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,9 +22,7 @@ public class PlayerListener implements Listener {
         Config config = BedrockPlayerSupport.getMainConfigManager().getConfigData();
         if (BedrockPlayerSupport.getFloodgateApi().isFloodgatePlayer(uuid)) {
             if (config.enableBackForm()) {
-                Bukkit.getScheduler().runTaskLaterAsynchronously(BedrockPlayerSupport.getInstance(), () -> {
-                    MainForm.getInstance().openBedrockBackForm(player);
-                }, 20L);
+                BedrockPlayerSupport.getScheduler().runTaskAsynchronously(() -> MainForm.getInstance().openBedrockBackForm(player));
             }
         }
     }

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/PlayerListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/PlayerListener.java
@@ -22,7 +22,7 @@ public class PlayerListener implements Listener {
         Config config = BedrockPlayerSupport.getMainConfigManager().getConfigData();
         if (BedrockPlayerSupport.getFloodgateApi().isFloodgatePlayer(uuid)) {
             if (config.enableBackForm()) {
-                BedrockPlayerSupport.getScheduler().runTaskAsynchronously(() -> MainForm.getInstance().openBedrockBackForm(player));
+                BedrockPlayerSupport.getScheduler().runTaskLaterAsynchronously(() -> MainForm.getInstance().openBedrockBackForm(player),20L);
             }
         }
     }

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/CatSeedLoginListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/CatSeedLoginListener.java
@@ -55,7 +55,7 @@ public class CatSeedLoginListener implements Listener {
                             lp.crypt();
                             CatSeedLogin.sql.add(lp);
                             LoginPlayerHelper.add(lp);
-                            Bukkit.getScheduler().runTask(CatSeedLogin.instance, () -> {
+                            BedrockPlayerSupport.getScheduler().runTask(CatSeedLogin.instance, () -> {
                                 CatSeedPlayerRegisterEvent event1 = new CatSeedPlayerRegisterEvent(player);
                                 Bukkit.getServer().getPluginManager().callEvent(event1);
                             });

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/teleport/HuskHomesTeleportListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/teleport/HuskHomesTeleportListener.java
@@ -17,12 +17,12 @@ public class HuskHomesTeleportListener implements Listener {
     @EventHandler
     public void onReceiveTeleportRequestEvent(ReceiveTeleportRequestEvent event) {
         TeleportRequest.Type requestType = event.getRequest().getType();
-        Player requestor = Bukkit.getPlayer(event.getRequest().getRequesterName());
+        Player requester = Bukkit.getPlayer(event.getRequest().getRequesterName());
         Player receiver = Bukkit.getPlayer(event.getRecipient().getUuid());
         if (requestType == TeleportRequest.Type.TPA) {
-            MainForm.getInstance().openBedrockTeleportHereForm(TeleportType.Tpa, requestor, receiver);
+            MainForm.getInstance().openBedrockTeleportHereForm(TeleportType.Tpa, requester, receiver);
         } else if (requestType == TeleportRequest.Type.TPA_HERE) {
-            MainForm.getInstance().openBedrockTeleportHereForm(TeleportType.TpaHere, requestor, receiver);
+            MainForm.getInstance().openBedrockTeleportHereForm(TeleportType.TpaHere, requester, receiver);
         }
     }
 

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/util/Update.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/util/Update.java
@@ -25,5 +25,6 @@ public class Update {
         } catch (IOException e) {
             BedrockPlayerSupport.getInstance().getLogger().info("Unable to check for updates: " + e.getMessage());
         }
-    }}
+    }
+}
 

--- a/src/main/java/cn/dsnbo/bedrockplayersupport/util/Update.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/util/Update.java
@@ -1,8 +1,6 @@
 package cn.dsnbo.bedrockplayersupport.util;
 
 import cn.dsnbo.bedrockplayersupport.BedrockPlayerSupport;
-import com.tcoded.folialib.FoliaLib;
-import org.bukkit.Bukkit;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,13 +14,7 @@ import java.util.function.Consumer;
 public class Update {
     private static final int spigotResourceId = 1145141919; // Spigot resource id
     public static void checkUpdate(Consumer<String> consumer) {
-        try {
-            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
-            FoliaLib foliaLib = new FoliaLib(BedrockPlayerSupport.getInstance());
-            foliaLib.getImpl().runAsync((task) -> getVersion(consumer));
-        } catch (ClassNotFoundException e) {
-            Bukkit.getScheduler().runTaskAsynchronously(BedrockPlayerSupport.getInstance(), () -> getVersion(consumer));
-        }
+        BedrockPlayerSupport.getScheduler().runTaskAsynchronously(() -> getVersion(consumer));
     }
 
     public static void getVersion(final Consumer<String> consumer) {


### PR DESCRIPTION
Changes:
1. Remove unused dependencies (Folia-API)
2. Migrate all BukkitSchedulers to UniversalScheduler
3. Removed dependency folialib(We already have UniversalScheduler)