### PR TITLE
修复AuthMe自动注册后首次仍需登录的问题

### DIFF
--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/AuthMeListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/AuthMeListener.java
@@ -37,7 +37,7 @@ public class AuthMeListener implements Listener {
         } else {
           if (config.enableRegister()) {
             String password = StringUtil.randomString(config.passwordLength());
-            AuthMeApi.getInstance().registerPlayer(playerName, password);
+            AuthMeApi.getInstance().forceRegister(player, password);
             player.sendMessage(
                 BedrockPlayerSupport.getMiniMessage().deserialize(language.registerSuccessfully()
                     .replaceAll("%password%", password)));


### PR DESCRIPTION
万恶的AuthMeApi的registerPlayer方法没有自动登录，只能forceRegister了
解释一下为什么不forceLogin：
registerPlayer方法如果注册不成功还会返回false，也就是说用forceLogin还得加一层判断