### PR TITLE
 Delayed AuthMe auto login to prevent multiple login notice

### DIFF
--- a/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/AuthMeListener.java
+++ b/src/main/java/cn/dsnbo/bedrockplayersupport/listener/login/AuthMeListener.java
@@ -26,24 +26,26 @@ public class AuthMeListener implements Listener {
     String playerName = player.getName();
     Config config = BedrockPlayerSupport.getMainConfigManager().getConfigData();
     Language language = BedrockPlayerSupport.getLanguageConfigManager().getConfigData();
-    if (FloodgateApi.getInstance().isFloodgatePlayer(playerUuid)) {
-      if (!AuthMeApi.getInstance().isAuthenticated(player)) {
-        if (AuthMeApi.getInstance().isRegistered(playerName)) {
-          if (config.enableLogin()) {
-            AuthMeApi.getInstance().forceLogin(player);
-            player.sendMessage(
-                BedrockPlayerSupport.getMiniMessage().deserialize(language.loginSuccessfully()));
-          }
-        } else {
-          if (config.enableRegister()) {
-            String password = StringUtil.randomString(config.passwordLength());
-            AuthMeApi.getInstance().forceRegister(player, password);
-            player.sendMessage(
+    BedrockPlayerSupport.getScheduler().runTaskLater(player, () -> {
+      if (FloodgateApi.getInstance().isFloodgatePlayer(playerUuid)) {
+        if (!AuthMeApi.getInstance().isAuthenticated(player)) {
+          if (AuthMeApi.getInstance().isRegistered(playerName)) {
+            if (config.enableLogin()) {
+              AuthMeApi.getInstance().forceLogin(player);
+              player.sendMessage(
+                  BedrockPlayerSupport.getMiniMessage().deserialize(language.loginSuccessfully()));
+            }
+          } else {
+            if (config.enableRegister()) {
+              String password = StringUtil.randomString(config.passwordLength());
+              AuthMeApi.getInstance().forceRegister(player, password);
+              player.sendMessage(
                 BedrockPlayerSupport.getMiniMessage().deserialize(language.registerSuccessfully()
                     .replaceAll("%password%", password)));
+            }
           }
         }
       }
-    }
-  }
+    }, 20L);
+  }                                            
 }


### PR DESCRIPTION
When a Bedrock player logged in with session restore, he will receive the following notice: "You have logged in already!

This pull request fixed this by delayed running Bedrock auto login