### PR TITLE
refactor(form): implement BasicForm interface for form classes

### DIFF
--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/BedrockPlayerSupport.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/BedrockPlayerSupport.kt
@@ -39,11 +39,7 @@ class BedrockPlayerSupport : JavaPlugin() {
         lateinit var scheduler: TaskScheduler
         lateinit var languageInUse: String
         lateinit var mainForm: MainForm
-        lateinit var cmiForm: CMIForm
-        lateinit var essxForm: EssXForm
-        lateinit var huskhomesForm: HuskHomesForm
-        lateinit var atForm: ATForm
-        lateinit var sunlightForm: SunLightForm
+        lateinit var basicForm: BasicForm
         lateinit var floodgateApi: FloodgateApi
         val miniMessage = MiniMessage.miniMessage()
         val legacySection = LegacyComponentSerializer.legacySection()
@@ -142,27 +138,27 @@ class BedrockPlayerSupport : JavaPlugin() {
         val enableRTF = mainConfigManager.getConfigData().enableReceiveTeleportForm()
         when (basicPlugin) {
             BasicPlugin.CMI -> {
-                cmiForm = CMIForm()
+                basicForm = CMIForm()
                 if (enableRTF) pluginManager.registerEvents(CMIListener(), this)
             }
 
             BasicPlugin.ESSENTIALS -> {
-                essxForm = EssXForm()
+                basicForm = EssXForm()
                 if (enableRTF) pluginManager.registerEvents(EssXListener(), this)
             }
 
             BasicPlugin.HUSKHOMES -> {
-                huskhomesForm = HuskHomesForm()
+                basicForm = HuskHomesForm()
                 if (enableRTF) pluginManager.registerEvents(HuskHomesListener(), this)
             }
 
             BasicPlugin.ADVANCEDTELEPORT -> {
-                atForm = ATForm()
+                basicForm = ATForm()
                 if (enableRTF) pluginManager.registerEvents(ATListener(), this)
             }
 
             BasicPlugin.SUNLIGHT -> {
-                sunlightForm = SunLightForm()
+                basicForm = SunLightForm()
                 if (enableRTF) pluginManager.registerEvents(SunLightListener(), this)
             }
 
@@ -200,9 +196,7 @@ class BedrockPlayerSupport : JavaPlugin() {
             getCommand("homegui")?.setExecutor(HomeFormCommand())
         }
         if (config.enablePublicHomeForm()) {
-            if (basicPlugin == BasicPlugin.HUSKHOMES) {
-                getCommand("phomegui")?.setExecutor(PublicHomeFormCommand())
-            }
+            getCommand("phomegui")?.setExecutor(PublicHomeFormCommand())
         }
         if (config.enableWarpForm()) {
             getCommand("warpgui")?.setExecutor(WarpFormCommand())

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/command/PublicHomeFormCommand.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/command/PublicHomeFormCommand.kt
@@ -1,6 +1,7 @@
 package cc.dsnb.bedrockplayersupport.command
 
 import cc.dsnb.bedrockplayersupport.BedrockPlayerSupport
+import cc.dsnb.bedrockplayersupport.form.basic.HuskHomesForm
 import cc.dsnb.bedrockplayersupport.util.StringUtil
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
@@ -17,7 +18,10 @@ class PublicHomeFormCommand : CommandExecutor {
     ): Boolean {
         if (sender is Player) {
             if (BedrockPlayerSupport.floodgateApi.isFloodgatePlayer(sender.uniqueId)) {
-                BedrockPlayerSupport.huskhomesForm.sendPublicHomeForm(sender)
+                val basicForm = BedrockPlayerSupport.basicForm
+                if (basicForm is HuskHomesForm) {
+                    basicForm.sendPublicHomeForm(sender)
+                }
             } else {
                 sender.sendMessage(
                     StringUtil.formatTextToComponent(

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/MainForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/MainForm.kt
@@ -1,10 +1,13 @@
 package cc.dsnb.bedrockplayersupport.form
 
-import cc.dsnb.bedrockplayersupport.BasicPlugin.*
+import cc.dsnb.bedrockplayersupport.BasicPlugin.HUSKHOMES
 import cc.dsnb.bedrockplayersupport.BedrockPlayerSupport
 import cc.dsnb.bedrockplayersupport.TeleportType
 import cc.dsnb.bedrockplayersupport.config.LangConfig
 import cc.dsnb.bedrockplayersupport.config.MainConfig
+import cc.dsnb.bedrockplayersupport.form.basic.CMIForm
+import cc.dsnb.bedrockplayersupport.form.basic.EssXForm
+import cc.dsnb.bedrockplayersupport.form.basic.SunLightForm
 import cc.dsnb.bedrockplayersupport.util.StringUtil
 import net.william278.huskhomes.BukkitHuskHomes
 import net.william278.huskhomes.api.HuskHomesAPI
@@ -14,7 +17,6 @@ import org.bukkit.entity.Player
 import org.geysermc.cumulus.form.CustomForm
 import org.geysermc.cumulus.form.ModalForm
 import org.geysermc.cumulus.form.SimpleForm
-import java.util.*
 
 /**
  * @author DongShaoNB
@@ -128,31 +130,8 @@ class MainForm {
             .validResultHandler { simpleFormResponse ->
                 when (simpleFormResponse.clickedButtonId()) {
                     0 -> openBedrockPlayerSetHomeForm(player)
-                    1 -> {
-                        when (BedrockPlayerSupport.basicPlugin) {
-                            CMI -> BedrockPlayerSupport.cmiForm.sendDelHomeForm(player)
-                            ESSENTIALS -> BedrockPlayerSupport.essxForm.sendDelHomeForm(player)
-                            HUSKHOMES -> BedrockPlayerSupport.huskhomesForm.sendDelHomeForm(player)
-                            ADVANCEDTELEPORT -> BedrockPlayerSupport.atForm.sendDelHomeForm(player)
-                            SUNLIGHT -> BedrockPlayerSupport.sunlightForm.sendDelHomeForm(player)
-                            NONE -> {
-                                // Don't need to do anything
-                            }
-                        }
-                    }
-
-                    2 -> {
-                        when (BedrockPlayerSupport.basicPlugin) {
-                            CMI -> BedrockPlayerSupport.cmiForm.sendGoHomeForm(player)
-                            ESSENTIALS -> BedrockPlayerSupport.essxForm.sendGoHomeForm(player)
-                            HUSKHOMES -> BedrockPlayerSupport.huskhomesForm.sendGoHomeForm(player)
-                            ADVANCEDTELEPORT -> BedrockPlayerSupport.atForm.sendGoHomeForm(player)
-                            SUNLIGHT -> BedrockPlayerSupport.sunlightForm.sendGoHomeForm(player)
-                            NONE -> {
-                                // Don't need to do anything
-                            }
-                        }
-                    }
+                    1 -> BedrockPlayerSupport.basicForm.sendDelHomeForm(player)
+                    2 -> BedrockPlayerSupport.basicForm.sendGoHomeForm(player)
                 }
             }
         BedrockPlayerSupport.floodgateApi.sendForm(uuid, form)
@@ -184,26 +163,15 @@ class MainForm {
     }
 
     fun openBedrockWarpForm(player: Player) {
-        when (BedrockPlayerSupport.basicPlugin) {
-            CMI -> BedrockPlayerSupport.cmiForm.sendWarpForm(player)
-            ESSENTIALS -> BedrockPlayerSupport.essxForm.sendWarpForm(player)
-            HUSKHOMES -> BedrockPlayerSupport.huskhomesForm.sendWarpForm(player)
-            ADVANCEDTELEPORT -> BedrockPlayerSupport.atForm.sendWarpForm(player)
-            SUNLIGHT -> BedrockPlayerSupport.sunlightForm.sendWarpForm(player)
-            NONE -> {
-                // Don't need to do anything
-            }
-        }
+        BedrockPlayerSupport.basicForm.sendWarpForm(player)
     }
 
     fun openBedrockKitForm(player: Player) {
-        when (BedrockPlayerSupport.basicPlugin) {
-            CMI -> BedrockPlayerSupport.cmiForm.sendKitForm(player)
-            ESSENTIALS -> BedrockPlayerSupport.essxForm.sendKitForm(player)
-            SUNLIGHT -> BedrockPlayerSupport.sunlightForm.sendKitForm(player)
-            else -> {
-                // Don't need to do anything
-            }
+        val basicForm = BedrockPlayerSupport.basicForm
+        when (basicForm) {
+            is CMIForm -> basicForm.sendKitForm(player)
+            is EssXForm -> basicForm.sendKitForm(player)
+            is SunLightForm -> basicForm.sendKitForm(player)
         }
     }
 }

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/ATForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/ATForm.kt
@@ -7,9 +7,9 @@ import io.github.niestrat99.advancedteleport.api.AdvancedTeleportAPI
 import org.bukkit.entity.Player
 import org.geysermc.cumulus.form.SimpleForm
 
-class ATForm {
+class ATForm : BasicForm {
 
-    fun sendDelHomeForm(player: Player) {
+    override fun sendDelHomeForm(player: Player) {
         val atPlayer = ATPlayer.getPlayer(player)
         val playerHomesList = atPlayer.homes
         val form = SimpleForm.builder()
@@ -26,7 +26,7 @@ class ATForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendGoHomeForm(player: Player) {
+    override fun sendGoHomeForm(player: Player) {
         val atPlayer = ATPlayer.getPlayer(player)
         val playerHomesList = atPlayer.homes
         val form = SimpleForm.builder()
@@ -43,7 +43,7 @@ class ATForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendWarpForm(player: Player) {
+    override fun sendWarpForm(player: Player) {
         val warps = AdvancedTeleportAPI.getWarps()
         val form = SimpleForm.builder()
             .title(

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/BasicForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/BasicForm.kt
@@ -1,0 +1,9 @@
+package cc.dsnb.bedrockplayersupport.form.basic
+
+import org.bukkit.entity.Player
+
+interface BasicForm {
+    fun sendDelHomeForm(player: Player)
+    fun sendGoHomeForm(player: Player)
+    fun sendWarpForm(player: Player)
+}

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/CMIForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/CMIForm.kt
@@ -9,9 +9,9 @@ import org.geysermc.cumulus.form.SimpleForm
 /**
  * @author DongShaoNB
  */
-class CMIForm {
+class CMIForm : BasicForm {
 
-    fun sendDelHomeForm(player: Player) {
+    override fun sendDelHomeForm(player: Player) {
         val cmiUser = CMI.getInstance().playerManager.getUser(player)
         val playerHomesList = cmiUser.homes
         val form = SimpleForm.builder()
@@ -28,7 +28,7 @@ class CMIForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendGoHomeForm(player: Player) {
+    override fun sendGoHomeForm(player: Player) {
         val cmiUser = CMI.getInstance().playerManager.getUser(player)
         val playerHomesList = cmiUser.homes
         val form = SimpleForm.builder()
@@ -45,7 +45,7 @@ class CMIForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendWarpForm(player: Player) {
+    override fun sendWarpForm(player: Player) {
         val warps = CMI.getInstance().warpManager.warps
         val form = SimpleForm.builder()
             .title(

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/EssXForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/EssXForm.kt
@@ -11,9 +11,9 @@ import org.geysermc.cumulus.form.SimpleForm
 /**
  * @author DongShaoNB
  */
-class EssXForm {
+class EssXForm : BasicForm {
 
-    fun sendDelHomeForm(player: Player) {
+    override fun sendDelHomeForm(player: Player) {
         val userHomes =
             User(player, Bukkit.getPluginManager().getPlugin("Essentials") as Essentials).homes
         val form = SimpleForm.builder()
@@ -30,7 +30,7 @@ class EssXForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendGoHomeForm(player: Player) {
+    override fun sendGoHomeForm(player: Player) {
         val userHomes =
             User(player, Bukkit.getPluginManager().getPlugin("Essentials") as Essentials).homes
         val form = SimpleForm.builder()
@@ -47,7 +47,7 @@ class EssXForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendWarpForm(player: Player) {
+    override fun sendWarpForm(player: Player) {
         val userWarps = (Bukkit.getPluginManager().getPlugin("Essentials") as Essentials).warps.list
         val form = SimpleForm.builder()
             .title(

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/HuskHomesForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/HuskHomesForm.kt
@@ -9,27 +9,9 @@ import org.geysermc.cumulus.form.SimpleForm
 /**
  * @author DongShaoNB
  */
-class HuskHomesForm {
+class HuskHomesForm : BasicForm {
 
-    fun sendPublicHomeForm(player: Player) {
-        val publicHomes = HuskHomesAPI.getInstance().publicHomes
-        val form = SimpleForm.builder()
-            .title(
-                StringUtil.formatTextToString(
-                    player,
-                    BedrockPlayerSupport.langConfigManager.getConfigData().publicHomeFormTitle()
-                )
-            )
-            .validResultHandler { simpleFormResponse ->
-                player.chat("/phome " + simpleFormResponse.clickedButton().text())
-            }
-        publicHomes.thenAccept { homeList ->
-            homeList.forEach { form.button(it.name) }
-            BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
-        }
-    }
-
-    fun sendDelHomeForm(player: Player) {
+    override fun sendDelHomeForm(player: Player) {
         val onlineUser = HuskHomesAPI.getInstance().adaptUser(player)
         val userHomes = HuskHomesAPI.getInstance().getUserHomes(onlineUser)
         val form = SimpleForm.builder()
@@ -48,7 +30,7 @@ class HuskHomesForm {
         }
     }
 
-    fun sendGoHomeForm(player: Player) {
+    override fun sendGoHomeForm(player: Player) {
         val onlineUser = HuskHomesAPI.getInstance().adaptUser(player)
         val userHomes = HuskHomesAPI.getInstance().getUserHomes(onlineUser)
         val form = SimpleForm.builder()
@@ -67,7 +49,7 @@ class HuskHomesForm {
         }
     }
 
-    fun sendWarpForm(player: Player) {
+    override fun sendWarpForm(player: Player) {
         val warps = HuskHomesAPI.getInstance().warps
         val form = SimpleForm.builder()
             .title(
@@ -81,6 +63,24 @@ class HuskHomesForm {
             }
         warps.thenAccept { warpList ->
             warpList.forEach { form.button(it.name) }
+            BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
+        }
+    }
+
+    fun sendPublicHomeForm(player: Player) {
+        val publicHomes = HuskHomesAPI.getInstance().publicHomes
+        val form = SimpleForm.builder()
+            .title(
+                StringUtil.formatTextToString(
+                    player,
+                    BedrockPlayerSupport.langConfigManager.getConfigData().publicHomeFormTitle()
+                )
+            )
+            .validResultHandler { simpleFormResponse ->
+                player.chat("/phome " + simpleFormResponse.clickedButton().text())
+            }
+        publicHomes.thenAccept { homeList ->
+            homeList.forEach { form.button(it.name) }
             BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
         }
     }

--- a/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/SunLightForm.kt
+++ b/src/main/kotlin/cc/dsnb/bedrockplayersupport/form/basic/SunLightForm.kt
@@ -8,11 +8,10 @@ import su.nightexpress.sunlight.SunLightAPI
 import su.nightexpress.sunlight.module.kits.KitsModule
 import su.nightexpress.sunlight.module.warps.WarpsModule
 
-class SunLightForm {
+class SunLightForm : BasicForm {
 
-    fun sendDelHomeForm(player: Player) {
+    override fun sendDelHomeForm(player: Player) {
         val slUser = SunLightAPI.PLUGIN.userManager.getUserData(player)
-        player.sendMessage(slUser.id)
         val playerHomesList = SunLightAPI.PLUGIN.data.getHomes(slUser.id)
         val form = SimpleForm.builder()
             .title(
@@ -28,7 +27,7 @@ class SunLightForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendGoHomeForm(player: Player) {
+    override fun sendGoHomeForm(player: Player) {
         val slUser = SunLightAPI.PLUGIN.userManager.getUserData(player)
         val playerHomesList = SunLightAPI.PLUGIN.data.getHomes(slUser.id)
         val form = SimpleForm.builder()
@@ -45,7 +44,7 @@ class SunLightForm {
         BedrockPlayerSupport.floodgateApi.sendForm(player.uniqueId, form)
     }
 
-    fun sendWarpForm(player: Player) {
+    override fun sendWarpForm(player: Player) {
         val warps = SunLightAPI.PLUGIN.moduleManager.getModule(WarpsModule::class.java).let {
             if (it.isPresent) {
                 it.get().warps


### PR DESCRIPTION
- Create BasicForm interface with common form methods
- Update ATForm, CMIForm, EssXForm, HuskHomesForm, and SunLightForm to implement BasicForm
- Refactor BedrockPlayerSupport class to use BasicForm instead of individual form classes
- Update MainForm and PublicHomeFormCommand to work with the new BasicForm implementation